### PR TITLE
refactor: chagne kafka-ui upstream image

### DIFF
--- a/kubernetes/templates/kafka-ui/deployment.yaml
+++ b/kubernetes/templates/kafka-ui/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: kafka-ui
-        image: ghcr.io/kafbat/kafka-ui
+        image: ghcr.io/kafbat/kafka-ui:latest
         ports:
         - containerPort: 8080
         env:

--- a/kubernetes/templates/kafka-ui/deployment.yaml
+++ b/kubernetes/templates/kafka-ui/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: kafka-ui
-        image: provectuslabs/kafka-ui:latest
+        image: ghcr.io/kafbat/kafka-ui
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
## 요약
- provectuslabs/kafka-ui 는 더이상 maintenance X. https://github.com/provectus/kafka-ui/discussions/4255
- kafbat/kafka-ui 로 갈음.