### PR TITLE
feat(flink): KafkaStringRecord Deserializer 추가

### DIFF
--- a/flink-version2/src/main/java/com/jongwow/flinkquick/DataStreamJob.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/DataStreamJob.java
@@ -19,13 +19,14 @@
 package com.jongwow.flinkquick;
 
 import com.jongwow.flinkquick.data.Message;
-import com.jongwow.flinkquick.utils.JsonConverter;
 import com.jongwow.flinkquick.data.json.JsonSchema;
+import com.jongwow.flinkquick.data.kafka.KafkaStringRecord;
+import com.jongwow.flinkquick.deserializer.KafkaDeserializationSchema;
 import com.jongwow.flinkquick.processor.JsonProcessor;
 import com.jongwow.flinkquick.transform.Transformation;
 import com.jongwow.flinkquick.transform.TransformationFactory;
+import com.jongwow.flinkquick.utils.JsonConverter;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -55,8 +56,8 @@ public class DataStreamJob {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
 
-        KafkaSource<String> source = getKafkaSource();
-        DataStreamSource<String> kafkaStream = env.fromSource(source, WatermarkStrategy.noWatermarks(), "Kafka Source");
+        KafkaSource<KafkaStringRecord> source = getKafkaSource();
+        DataStreamSource<KafkaStringRecord> kafkaStream = env.fromSource(source, WatermarkStrategy.noWatermarks(), "Kafka Source");
 
 //        Transformation<Message> transformation = (Transformation<Message>) TransformationFactory.getTransformation("dms", null);
         Transformation<Message> transformation = (Transformation<Message>) TransformationFactory.getTransformation("json", getJsonSchemaFromArgs());
@@ -73,8 +74,8 @@ public class DataStreamJob {
     }
 
 
-    public static KafkaSource<String> getKafkaSource() {
-        return KafkaSource.<String>builder()
+    public static KafkaSource<KafkaStringRecord> getKafkaSource() {
+        return KafkaSource.<KafkaStringRecord>builder()
                 .setBootstrapServers("localhost:9095")
                 .setTopics("test-json-topic")
                 .setGroupId("my-group")
@@ -82,7 +83,7 @@ public class DataStreamJob {
                 .setProperty("sasl.mechanism", "PLAIN")
                 .setProperty("sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user1\" password=\"bYYnBX7ITw\";")
                 .setStartingOffsets(OffsetsInitializer.earliest())
-                .setValueOnlyDeserializer(new SimpleStringSchema())
+                .setDeserializer(new KafkaDeserializationSchema())
                 .build();
     }
 

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/data/DmsMessage.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/data/DmsMessage.java
@@ -6,6 +6,8 @@ public final class DmsMessage extends Message {
     private JsonNode data;
     private JsonNode metadata;
 
+    private Long regTs;
+
 
     public DmsMessage() {
     }
@@ -25,6 +27,10 @@ public final class DmsMessage extends Message {
 
     public void setMetadata(JsonNode metaObject) {
         this.metadata = metaObject;
+    }
+
+    public void setRegTs(Long regTs) {
+        this.regTs = regTs;
     }
 
     @Override

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/data/kafka/KafkaStringRecord.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/data/kafka/KafkaStringRecord.java
@@ -1,0 +1,24 @@
+package com.jongwow.flinkquick.data.kafka;
+
+import java.io.Serializable;
+
+public class KafkaStringRecord implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private long logAppendTime;
+    private String value;
+
+    public KafkaStringRecord(long logAppendTime, String value) {
+        this.logAppendTime = logAppendTime;
+        this.value = value;
+    }
+
+    public long getLogAppendTime() {
+        return logAppendTime;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}
+

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/data/kafka/KafkaStringRecord.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/data/kafka/KafkaStringRecord.java
@@ -5,8 +5,8 @@ import java.io.Serializable;
 public class KafkaStringRecord implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private long logAppendTime;
-    private String value;
+    private final long logAppendTime;
+    private final String value;
 
     public KafkaStringRecord(long logAppendTime, String value) {
         this.logAppendTime = logAppendTime;

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/deserializer/KafkaDeserializationSchema.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/deserializer/KafkaDeserializationSchema.java
@@ -1,0 +1,24 @@
+package com.jongwow.flinkquick.deserializer;
+
+import com.jongwow.flinkquick.data.kafka.KafkaStringRecord;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.util.Collector;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class KafkaDeserializationSchema implements KafkaRecordDeserializationSchema<KafkaStringRecord> {
+    @Override
+    public void deserialize(ConsumerRecord<byte[], byte[]> consumerRecord, Collector<KafkaStringRecord> collector) throws IOException {
+        String value = new String(consumerRecord.value());
+        long logAppendTime = consumerRecord.timestamp();
+        collector.collect(new KafkaStringRecord(logAppendTime, value));
+    }
+
+    @Override
+    public TypeInformation<KafkaStringRecord> getProducedType() {
+        return TypeInformation.of(KafkaStringRecord.class);
+    }
+}

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/deserializer/KafkaDeserializationSchema.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/deserializer/KafkaDeserializationSchema.java
@@ -7,11 +7,10 @@ import org.apache.flink.util.Collector;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 public class KafkaDeserializationSchema implements KafkaRecordDeserializationSchema<KafkaStringRecord> {
     @Override
-    public void deserialize(ConsumerRecord<byte[], byte[]> consumerRecord, Collector<KafkaStringRecord> collector) throws IOException {
+    public void deserialize(ConsumerRecord<byte[], byte[]> consumerRecord, Collector<KafkaStringRecord> collector) {
         String value = new String(consumerRecord.value());
         long logAppendTime = consumerRecord.timestamp();
         collector.collect(new KafkaStringRecord(logAppendTime, value));

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/processor/JsonProcessor.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/processor/JsonProcessor.java
@@ -1,16 +1,12 @@
 package com.jongwow.flinkquick.processor;
 
-import com.jongwow.flinkquick.data.DmsMessage;
-
 import com.jongwow.flinkquick.data.Message;
 import com.jongwow.flinkquick.data.kafka.KafkaStringRecord;
 import com.jongwow.flinkquick.transform.Transformation;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.util.Collector;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/processor/JsonProcessor.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/processor/JsonProcessor.java
@@ -3,6 +3,7 @@ package com.jongwow.flinkquick.processor;
 import com.jongwow.flinkquick.data.DmsMessage;
 
 import com.jongwow.flinkquick.data.Message;
+import com.jongwow.flinkquick.data.kafka.KafkaStringRecord;
 import com.jongwow.flinkquick.transform.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
@@ -14,7 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class JsonProcessor extends ProcessFunction<String, Message> {
+public class JsonProcessor extends ProcessFunction<KafkaStringRecord, Message> {
     private static final long serialVersionUID = 1L;
     private final Transformation<? extends Message> transformation;
 
@@ -36,7 +37,7 @@ public class JsonProcessor extends ProcessFunction<String, Message> {
     }
 
     @Override
-    public void processElement(String raw, ProcessFunction<String, Message>.Context context, Collector<Message> collector) throws Exception {
+    public void processElement(KafkaStringRecord raw, ProcessFunction<KafkaStringRecord, Message>.Context context, Collector<Message> collector) throws Exception {
         try {
             Message transform = transformation.transform(raw);
             collector.collect(transform);

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/transform/DmsTransformation.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/transform/DmsTransformation.java
@@ -1,6 +1,7 @@
 package com.jongwow.flinkquick.transform;
 
 import com.jongwow.flinkquick.data.DmsMessage;
+import com.jongwow.flinkquick.data.kafka.KafkaStringRecord;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -9,8 +10,8 @@ public class DmsTransformation implements Transformation<DmsMessage> {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     @Override
-    public DmsMessage transform(String raw) throws Exception {
-        JsonNode jsonNode = objectMapper.readTree(raw);
+    public DmsMessage transform(KafkaStringRecord raw) throws Exception {
+        JsonNode jsonNode = objectMapper.readTree(raw.getValue());
         JsonNode dataObject = jsonNode.get("data");
         JsonNode metaObject = jsonNode.get("metadata");
         //TODO: 어차피 json 이니까 check method 를 정의해서 transform 에서 구현하기
@@ -21,6 +22,7 @@ public class DmsTransformation implements Transformation<DmsMessage> {
         DmsMessage dmsMessage = new DmsMessage();
         dmsMessage.setData(dataObject);
         dmsMessage.setMetadata(metaObject);
+        dmsMessage.setRegTs(raw.getLogAppendTime());
         return dmsMessage;
     }
 }

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/transform/JsonTransformation.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/transform/JsonTransformation.java
@@ -3,6 +3,7 @@ package com.jongwow.flinkquick.transform;
 import com.jongwow.flinkquick.data.JsonMessage;
 import com.jongwow.flinkquick.data.json.JsonDataType;
 import com.jongwow.flinkquick.data.json.JsonSchema;
+import com.jongwow.flinkquick.data.kafka.KafkaStringRecord;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -18,9 +19,11 @@ public class JsonTransformation implements Transformation<JsonMessage>{
     }
 
     @Override
-    public JsonMessage transform(String raw) throws Exception {
+    public JsonMessage transform(KafkaStringRecord raw) throws Exception {
         JsonMessage jsonMessage = new JsonMessage();
-        JsonNode rootNode = objectMapper.readTree(raw);
+        JsonNode rootNode = objectMapper.readTree(raw.getValue());
+        //TODO: 개선하기
+        jsonMessage.addField("reg_ts", raw.getLogAppendTime());
         jsonSchema.columns.forEach(jsonColumn -> {
             JsonNode field = rootNode.get(jsonColumn.getColumnName());
             if (jsonColumn.getDataType() == JsonDataType.BIGINT) {

--- a/flink-version2/src/main/java/com/jongwow/flinkquick/transform/Transformation.java
+++ b/flink-version2/src/main/java/com/jongwow/flinkquick/transform/Transformation.java
@@ -1,11 +1,12 @@
 package com.jongwow.flinkquick.transform;
 
 import com.jongwow.flinkquick.data.Message;
+import com.jongwow.flinkquick.data.kafka.KafkaStringRecord;
 
 import java.io.Serializable;
 
 public interface Transformation<M extends Message> extends Serializable {
-    M transform(String raw) throws Exception;
+    M transform(KafkaStringRecord raw) throws Exception;
 }
 
 // 과연 serializable 한게 좋을 것인가?


### PR DESCRIPTION
## 요약
- kafka 로부터 바로 value 만 string 으로 읽으면 message 의 metadata (timestamp 등)을 읽을 수 없음
- 이를 해결하기 위해 KafkaStringRecord 를 정의하고 그에 해당하는 Deserializer 구현